### PR TITLE
Update dependencies across all frameworks

### DIFF
--- a/imperative/micronaut/README.md
+++ b/imperative/micronaut/README.md
@@ -1,8 +1,8 @@
-## Micronaut 4.4.2 Documentation
+## Micronaut 4.10.13 Documentation
 
-- [User Guide](https://docs.micronaut.io/4.4.2/guide/index.html)
-- [API Reference](https://docs.micronaut.io/4.4.2/api/index.html)
-- [Configuration Reference](https://docs.micronaut.io/4.4.2/guide/configurationreference.html)
+- [User Guide](https://docs.micronaut.io/4.10.13/guide/index.html)
+- [API Reference](https://docs.micronaut.io/4.10.13/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/4.10.13/guide/configurationreference.html)
 - [Micronaut Guides](https://guides.micronaut.io/index.html)
 ---
 

--- a/imperative/micronaut/build.gradle.kts
+++ b/imperative/micronaut/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.micronaut.application") version "4.6.1"
-    id("io.micronaut.aot") version "4.6.1"
+    id("io.micronaut.application") version "4.6.2"
+    id("io.micronaut.aot") version "4.6.2"
 }
 
 version = "0.1"
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")
-    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.7"))
+    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.13"))
     aotPlugins("io.micronaut.security:micronaut-security-aot")
 }
 

--- a/imperative/micronaut/gradle.properties
+++ b/imperative/micronaut/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.4.2
+micronautVersion=4.10.13

--- a/imperative/micronaut/gradle/wrapper/gradle-wrapper.properties
+++ b/imperative/micronaut/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/imperative/quarkus/gradle.properties
+++ b/imperative/quarkus/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.10.2
+quarkusPluginVersion=3.38.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.10.2
+quarkusPlatformVersion=3.38.1

--- a/imperative/quarkus/gradle/wrapper/gradle-wrapper.properties
+++ b/imperative/quarkus/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/imperative/spring-boot/build.gradle
+++ b/imperative/spring-boot/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.7'
+	id 'org.springframework.boot' version '4.1.0'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.graalvm.buildtools.native' version '0.11.4'
+	id 'org.graalvm.buildtools.native' version '1.0.0'
 }
 
 group = 'com.example.rest'

--- a/imperative/spring-boot/gradle/wrapper/gradle-wrapper.properties
+++ b/imperative/spring-boot/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/reactive/micronaut/README.md
+++ b/reactive/micronaut/README.md
@@ -1,8 +1,8 @@
-## Micronaut 4.4.2 Documentation
+## Micronaut 4.10.13 Documentation
 
-- [User Guide](https://docs.micronaut.io/4.4.2/guide/index.html)
-- [API Reference](https://docs.micronaut.io/4.4.2/api/index.html)
-- [Configuration Reference](https://docs.micronaut.io/4.4.2/guide/configurationreference.html)
+- [User Guide](https://docs.micronaut.io/4.10.13/guide/index.html)
+- [API Reference](https://docs.micronaut.io/4.10.13/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/4.10.13/guide/configurationreference.html)
 - [Micronaut Guides](https://guides.micronaut.io/index.html)
 ---
 

--- a/reactive/micronaut/build.gradle.kts
+++ b/reactive/micronaut/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("io.micronaut.application") version "4.6.1"
-    id("io.micronaut.aot") version "4.6.1"
+    id("io.micronaut.application") version "4.6.2"
+    id("io.micronaut.aot") version "4.6.2"
 }
 
 version = "0.1"
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")
-    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.7"))
+    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.13"))
     aotPlugins("io.micronaut.security:micronaut-security-aot")
 }
 

--- a/reactive/micronaut/gradle.properties
+++ b/reactive/micronaut/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.4.2
+micronautVersion=4.10.13

--- a/reactive/micronaut/gradle/wrapper/gradle-wrapper.properties
+++ b/reactive/micronaut/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/reactive/quarkus/gradle.properties
+++ b/reactive/quarkus/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 quarkusPluginId=io.quarkus
-quarkusPluginVersion=3.10.2
+quarkusPluginVersion=3.38.1
 quarkusPlatformGroupId=io.quarkus.platform
 quarkusPlatformArtifactId=quarkus-bom
-quarkusPlatformVersion=3.10.2
+quarkusPlatformVersion=3.38.1

--- a/reactive/quarkus/gradle/wrapper/gradle-wrapper.properties
+++ b/reactive/quarkus/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/reactive/spring-boot/build.gradle
+++ b/reactive/spring-boot/build.gradle
@@ -1,8 +1,8 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.7'
+	id 'org.springframework.boot' version '4.1.0'
 	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.graalvm.buildtools.native' version '0.11.4'
+	id 'org.graalvm.buildtools.native' version '1.0.0'
 }
 
 group = 'com.example.rest'

--- a/reactive/spring-boot/gradle/wrapper/gradle-wrapper.properties
+++ b/reactive/spring-boot/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- **Quarkus**: 3.10.2 → 3.38.1
- **Spring Boot**: 3.5.7 → 4.1.0
- **GraalVM native buildtools**: 0.11.4 → 1.0.0
- **Micronaut**: core 4.4.2 → 4.10.13, Gradle plugin 4.6.1 → 4.6.2, platform BOM 4.10.7 → 4.10.13
- **Gradle wrapper**: all projects updated to 9.7.0
- **Helidon**: already current at 4.5.2 (no changes)
- Micronaut READMEs updated to reflect new version in doc links