### PR TITLE
Fix Spring Boot image builds for Paketo Java 25 requirement

### DIFF
--- a/imperative/spring-boot/build.gradle
+++ b/imperative/spring-boot/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+tasks.named('bootBuildImage') {
+	environment = ['BP_JVM_VERSION': '25']
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/reactive/spring-boot/build.gradle
+++ b/reactive/spring-boot/build.gradle
@@ -24,6 +24,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+tasks.named('bootBuildImage') {
+	environment = ['BP_JVM_VERSION': '25']
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }


### PR DESCRIPTION
Spring Boot 4.x with the Paketo buildpack requires Java 25 at image build time. The `bootBuildImage` task has been failing in both imperative and reactive workflows since the Spring Boot 4.0.2 Dependabot upgrade with:

> the Java version from the downloaded NIK/GraalVM is lower than 25 and the Spring Boot version is >= 4.0.0

This sets `BP_JVM_VERSION=25` in the `bootBuildImage` task configuration for both Spring Boot projects.