### PR TITLE
Upgrade to Java 25 and Micronaut 5

### DIFF
--- a/.github/workflows/helidon.yml
+++ b/.github/workflows/helidon.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Configure Java 21
+      - name: Configure Java 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'gradle'
       - name: Run tests
         working-directory: ./${{ matrix.app }}

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |

--- a/.github/workflows/micronaut.yml
+++ b/.github/workflows/micronaut.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Configure Java 21
+      - name: Configure Java 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'gradle'
       - name: Run tests
         working-directory: ./${{ matrix.app }}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Configure Java 21
+      - name: Configure Java 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'gradle'
       - name: Run tests
         working-directory: ./${{ matrix.app }}

--- a/.github/workflows/reactive.yml
+++ b/.github/workflows/reactive.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |

--- a/.github/workflows/spring-boot.yml
+++ b/.github/workflows/spring-boot.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Configure Java 21
+      - name: Configure Java 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: 25
           cache: 'gradle'
       - name: Run tests
         working-directory: ./${{ matrix.app }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains example OAuth 2.0 resource servers built with imperative and reactive versions of Micronaut, Quarkus, Spring Boot, and Helidon. See the [imperative](imperative/demo.adoc) and [reactive](reactive/demo.adoc) demo scripts to see how these examples were created.
 
-**Prerequisites:** [Java 21 with GraalVM](https://sdkman.io/) and [HTTPie](https://httpie.io/).
+**Prerequisites:** [Java 25 with GraalVM](https://sdkman.io/) and [HTTPie](https://httpie.io/).
 
 * [Getting Started](#getting-started)
 * [Links](#links)
@@ -31,7 +31,7 @@ git clone https://github.com/mraible/java-rest-api-examples.git
 You will need a JDK with GraalVM and its native-image compiler. Using [SDKMAN](https://sdkman.io), run the following command and set it as the default:
 
 ```bash
-sdk install java 21.0.2-graalce
+sdk install java 25-graalce
 ```
 
 Next, you'll need a [free Auth0 developer account](https://auth0.com/signup). 

--- a/imperative/micronaut/README.md
+++ b/imperative/micronaut/README.md
@@ -1,8 +1,8 @@
-## Micronaut 4.10.13 Documentation
+## Micronaut 5.1.0 Documentation
 
-- [User Guide](https://docs.micronaut.io/4.10.13/guide/index.html)
-- [API Reference](https://docs.micronaut.io/4.10.13/api/index.html)
-- [Configuration Reference](https://docs.micronaut.io/4.10.13/guide/configurationreference.html)
+- [User Guide](https://docs.micronaut.io/5.1.0/guide/index.html)
+- [API Reference](https://docs.micronaut.io/5.1.0/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/5.1.0/guide/configurationreference.html)
 - [Micronaut Guides](https://guides.micronaut.io/index.html)
 ---
 

--- a/imperative/micronaut/build.gradle.kts
+++ b/imperative/micronaut/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.gradleup.shadow") version "9.6.1"
-    id("io.micronaut.application") version "4.6.2"
-    id("io.micronaut.aot") version "4.6.2"
+    id("io.micronaut.application") version "5.0.2"
+    id("io.micronaut.aot") version "5.0.2"
 }
 
 version = "0.1"
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")
-    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.13"))
+    aotPlugins(platform("io.micronaut.platform:micronaut-platform:5.1.0"))
     aotPlugins("io.micronaut.security:micronaut-security-aot")
 }
 
@@ -29,8 +29,8 @@ application {
     mainClass = "com.example.rest.Application"
 }
 java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
 }
 
 

--- a/imperative/micronaut/gradle.properties
+++ b/imperative/micronaut/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.13
+micronautVersion=5.1.0

--- a/imperative/quarkus/build.gradle
+++ b/imperative/quarkus/build.gradle
@@ -21,8 +21,8 @@ group 'com.example.rest'
 version '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 test {

--- a/imperative/spring-boot/build.gradle
+++ b/imperative/spring-boot/build.gradle
@@ -9,7 +9,7 @@ group = 'com.example.rest'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '21'
+	sourceCompatibility = '25'
 }
 
 repositories {

--- a/reactive/micronaut/README.md
+++ b/reactive/micronaut/README.md
@@ -1,8 +1,8 @@
-## Micronaut 4.10.13 Documentation
+## Micronaut 5.1.0 Documentation
 
-- [User Guide](https://docs.micronaut.io/4.10.13/guide/index.html)
-- [API Reference](https://docs.micronaut.io/4.10.13/api/index.html)
-- [Configuration Reference](https://docs.micronaut.io/4.10.13/guide/configurationreference.html)
+- [User Guide](https://docs.micronaut.io/5.1.0/guide/index.html)
+- [API Reference](https://docs.micronaut.io/5.1.0/api/index.html)
+- [Configuration Reference](https://docs.micronaut.io/5.1.0/guide/configurationreference.html)
 - [Micronaut Guides](https://guides.micronaut.io/index.html)
 ---
 

--- a/reactive/micronaut/build.gradle.kts
+++ b/reactive/micronaut/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.gradleup.shadow") version "9.6.1"
-    id("io.micronaut.application") version "4.6.2"
-    id("io.micronaut.aot") version "4.6.2"
+    id("io.micronaut.application") version "5.0.2"
+    id("io.micronaut.aot") version "5.0.2"
 }
 
 version = "0.1"
@@ -20,7 +20,7 @@ dependencies {
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")
-    aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.10.13"))
+    aotPlugins(platform("io.micronaut.platform:micronaut-platform:5.1.0"))
     aotPlugins("io.micronaut.security:micronaut-security-aot")
 }
 
@@ -29,8 +29,8 @@ application {
     mainClass = "com.example.rest.Application"
 }
 java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
+    sourceCompatibility = JavaVersion.toVersion("25")
+    targetCompatibility = JavaVersion.toVersion("25")
 }
 
 

--- a/reactive/micronaut/gradle.properties
+++ b/reactive/micronaut/gradle.properties
@@ -1,1 +1,1 @@
-micronautVersion=4.10.13
+micronautVersion=5.1.0

--- a/reactive/quarkus/build.gradle
+++ b/reactive/quarkus/build.gradle
@@ -21,8 +21,8 @@ group 'com.example.rest'
 version '1.0.0-SNAPSHOT'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 test {

--- a/reactive/spring-boot/build.gradle
+++ b/reactive/spring-boot/build.gradle
@@ -9,7 +9,7 @@ group = 'com.example.rest'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '21'
+	sourceCompatibility = '25'
 }
 
 repositories {


### PR DESCRIPTION
Micronaut 5.x requires Java 25, and the other frameworks all support it: Spring Boot 4.1 (min 17, max 26), Quarkus 3.38 (min 17), and Helidon 4.5 (min 21, recommends 25). This bumps the entire project from Java 21 to Java 25, enabling the Micronaut upgrade.

- All 6 CI workflows updated from Java 21 to Java 25
- Micronaut plugins from 4.6.2 to 5.0.2 and platform BOM from 4.10.13 to 5.1.0
- `sourceCompatibility` bumped to 25 across Micronaut, Quarkus, and Spring Boot
- Main README prerequisites updated to Java 25 with GraalVM
- Micronaut READMEs updated with 5.1.0 doc links