### PR TITLE
Update Helidon Dockerfiles to GraalVM 25 and Maven 3.9.9

### DIFF
--- a/imperative/helidon/Dockerfile.native
+++ b/imperative/helidon/Dockerfile.native
@@ -1,12 +1,12 @@
 
 # 1st stage, build the app
-FROM ghcr.io/graalvm/graalvm-community:21.0.0-ol9 as build
+FROM ghcr.io/graalvm/graalvm-community:25-ol9 as build
 
 WORKDIR /usr/share
 
 # Install maven
 RUN set -x && \
-    curl -O https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz && \
+    curl -O https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz && \
     tar -xvf apache-maven-*-bin.tar.gz  && \
     rm apache-maven-*-bin.tar.gz && \
     mv apache-maven-* maven && \

--- a/reactive/helidon/Dockerfile.native
+++ b/reactive/helidon/Dockerfile.native
@@ -1,12 +1,12 @@
 
 # 1st stage, build the app
-FROM ghcr.io/graalvm/graalvm-community:21.0.0-ol9 as build
+FROM ghcr.io/graalvm/graalvm-community:25-ol9 as build
 
 WORKDIR /usr/share
 
 # Install maven
 RUN set -x && \
-    curl -O https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz && \
+    curl -O https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz && \
     tar -xvf apache-maven-*-bin.tar.gz  && \
     rm apache-maven-*-bin.tar.gz && \
     mv apache-maven-* maven && \


### PR DESCRIPTION
The imperative and reactive image build workflows are failing at the Helidon native image step with `undefined reference to '__xmknod'`. This is a glibc symbol mismatch — GraalVM CE 21.0.0 was compiled against an older glibc that references `__xmknod`, but Oracle Linux 9's glibc 2.34+ no longer provides it.

This was pre-existing but was masked because the Spring Boot `bootBuildImage` step always failed first (fixed in #266), skipping Helidon.

- GraalVM base image: `21.0.0-ol9` to `25-ol9`
- Maven: 3.8.4 to 3.9.9